### PR TITLE
UI tweaks for current workflow

### DIFF
--- a/ImageOpener.js
+++ b/ImageOpener.js
@@ -89,9 +89,11 @@ function ImageOpener( processImage, target ) {
 
 
 	function handleDragOver(e) {
-		e.stopPropagation();
-		e.preventDefault();
-		e.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
+		if (e.dataTransfer.files) {
+			e.stopPropagation();
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
+		}
 	}
 
 
@@ -101,10 +103,15 @@ function ImageOpener( processImage, target ) {
 	}
 
 	function dropBehavior(e) {
-		console.log('Files are dropped', e);
-		e.stopPropagation();
-		e.preventDefault();
 		var files = e.dataTransfer.files;
+		
+		if (files) {
+			e.stopPropagation();
+			e.preventDefault();
+		} else {
+			console.log('Files are dropped', e);
+			return;
+		}
 
 		if (files.length) {
 			for (var i = 0; i < files.length; i++) {

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Lightbroom
 --
 
-Back in 2003, I created [this repostory](https://github.com/zz85/lightbroom/commit/124270abe79588366e7bd041f32851aa548ddbc9) because I had some wild ideas of building a better replacement to my lightroom workflow... (yeah it is never that easy but one can always have dreams...)
+Back in 2003, I created [this repostory](https://github.com/zz85/lightbroom/commit/124270abe79588366e7bd041f32851aa548ddbc9) because I had some [wild ideas](https://plus.google.com/117614030945250277079/posts/LcApD7CFF86) of building a better replacement to my lightroom workflow... (yeah it is never that easy but one can always dream...)
 
 ## Current State
 
 An Instagram-like desktop app developed with Electron and Web technologies for a simple photo retouching workflow.
-This iteration currently uses [CSSgram](https://github.com/una/CSSgram/) (which uses GPU accelerated CSS filters and blend modes) for instgram like filters.
+This iteration uses [CSSgram](https://github.com/una/CSSgram/) (that uses GPU accelerated CSS filters and blend modes) for Instagram like effects.
 
 ![screenshot 2015-12-30 04 36 58](https://cloud.githubusercontent.com/assets/314997/12041835/1473add4-aeb0-11e5-8a52-85bd959d062c.png)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@ Lightbroom
 
 Back in 2003, I created [this repostory](https://github.com/zz85/lightbroom/commit/124270abe79588366e7bd041f32851aa548ddbc9) because I had some [wild ideas](https://plus.google.com/117614030945250277079/posts/LcApD7CFF86) of building a better replacement to my lightroom workflow... (yeah it is never that easy but one can always dream...)
 
+## Current Features
+
+- Drag drop photos
+- Mass preview and apply filters
+- Mass export
+
+## Running the app
+
+`electron app.js`
+
+### Prerequisite
+
+Electron
+
+`npm install -g electron-prebuilt`
+
+Node modules
+
+`npm install --production`
+
 ## Current State
 
 An Instagram-like desktop app developed with Electron and Web technologies for a simple photo retouching workflow.
@@ -11,12 +31,6 @@ This iteration uses [CSSgram](https://github.com/una/CSSgram/) (that uses GPU ac
 ![screenshot 2015-12-30 04 36 58](https://cloud.githubusercontent.com/assets/314997/12041835/1473add4-aeb0-11e5-8a52-85bd959d062c.png)
 
 ![lightbroom1](https://cloud.githubusercontent.com/assets/314997/12041841/282d7f62-aeb0-11e5-841b-726cc98bae1c.gif)
-
-## Current Features
-
-- Drag drop photos
-- Mass preview and apply filters
-- Mass export
 
 ## Contact
 [@blurspline](http://twitter.com/blurspline)

--- a/capture-image.js
+++ b/capture-image.js
@@ -65,7 +65,7 @@ function load (photo, style, filename, longest, orientation) {
 			count++;
 			if (count < 3 || win.isLoading()) {
 				// not sure if this actually is useful.
-				// 'did-stop-loading'
+				// 'did-stop-loading'  perhaps naturalWidth can give clues too?
 				return requestAnimationFrame(wait);
 			}
 			console.timeEnd('raf')

--- a/index.html
+++ b/index.html
@@ -4,10 +4,25 @@
         <link href='https://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic' rel='stylesheet' type='text/css'>
 	</head>
 <body>
-	<link rel="stylesheet" href="cssgram.min.css">
+	<link rel="stylesheet" href="cssgram.min.css"></link>
+	<link rel="stylesheet" href="lightbroom.css"></link>
 	<script src="ImageOpener.js"></script>
 	<script src="photo.js"></script>
 	<script src="node_modules/exif-js/exif.js"></script>
+
+	<!--
+		initial potatoe prototype from http://jabtunes.com/labs/potatoe/ series
+
+		TODO
+		- Remove images
+		- Remember last effect, last output settings (resolution)
+
+		DONE
+		1. Photo rotation (transform in canvas, pass css transform)
+		2. Output size (easy, can use css for now)
+		3. Save last target folder
+	-->
+
 
     <div id="topbar">
 		<!-- toolbar here -->
@@ -27,7 +42,6 @@
 			<button onclick="sizeThumbnails(120)">S</button>
 			<button onclick="sizeThumbnails(240)">M</button>
 			<button onclick="sizeThumbnails(360)">L</button>
-
 		</div>
 
 		<div class="txt-drag-your-photos-here" style="bottom: 0">
@@ -40,216 +54,22 @@
 
 	<div id="filters"></div>
 
-	<!--
-		NOT IN USE
-		<div id="peeks">
-		</div>
-	-->
-
 	<div id="sliders"></div>
 
-	<div id="loupe">
-		<button onclick="togglePreviewSlider()" style="float:right;">v</button>
+	<div>
+		<div id="loupe">
+			<button onclick="togglePreviewSlider()" style="float:right;">v</button>
 
-		<div id="big">
+			<div id="big">
 
+			</div>
+		</div>
+
+		<div id="preview">
+			<div id="preview-slider"></div>
+			<!-- film strip here -->
 		</div>
 	</div>
-
-	<div id="preview">
-		<div id="preview-slider"></div>
-		<!-- film strip here -->
-	</div>
-
-	<!--
-		initial potatoe prototype from http://jabtunes.com/labs/potatoe/ series
-
-		TODO
-		- Remove images
-		- Remember last effect, last output settings (resolution)
-
-		DONE
-		1. Photo rotation (transform in canvas, pass css transform)
-		2. Output size (easy, can use css for now)
-		3. Save last target folder
-	-->
-
-	<style>
-		body {
-            font-family: 'Lato', sans-serif;
-			background-color: #333740;
-			color: #ddd;
-			font-size: 13px;
-            margin: 0;
-            padding: 0;
-			outline: none;
-		}
-
-        #topbar {
-            background: #555862;
-            box-shadow: 0px 1px 0px 0px #24272D;
-            width: 100%;
-            height: 50px;
-			display: flex;
-        }
-
-		#save-options {
-			transition: width 400ms ease-out;
-			width: 90px;
-			display: inline-block;
-			overflow: hidden;
-		}
-
-		#save-options:hover {
-			width: 670px;
-		}
-
-		.pic {
-			/*max-height: 320px;
-			max-width: 320px;*/
-
-			margin: 5px;
-			float: left;
-		}
-
-		.pic img, .effect img {
-			border-radius: 4px;
-		}
-
-		.peek {
-			max-height: 120px;
-			max-width: 120px;
-			float: left;
-			margin: 2px;
-		}
-
-		.nofilter img {
-			width: 100%;
-		}
-
-		.selected-effect {
-			border: 2px solid #ccc;
-			box-sizing: border-box;
-		}
-
-		.selected-effect:hover {
-			border: 2px solid #fff;
-		}
-
-		#filters {
-			display: flex;
-			overflow: scroll;
-            background-color: #23262C;
-            box-shadow: 0px 1px 0px 0px rgba(255,255,255,0.30);
-            padding: 14px;
-            font-size: 13px;
-			transition: height 250ms;
-		}
-
-		button {
-            font-family: 'Lato', sans-serif;
-			padding: 10px;
-			margin: 4px 4px 14px 4px;
-			background-image: linear-gradient(-180deg, #7B7E87 0%, #555862 100%);
-			border: 1px solid #292B31;
-			box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.30), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.60);
-			border-radius: 4px;
-			color: #eaeaea;
-            font-size: 13px;
-
-			text-overflow: ellipsis;
-			white-space: nowrap;
-		}
-
-		.effect {
-			width: 130px;
-			display: block;
-			text-align: center;
-			font-weight: bold;
-			display: block;
-		}
-
-		button:active {
-			box-shadow: 0px 1px 1px 0px rgba(255, 255, 255, 0.30), inset 0px 0px 4px 0px rgba(0, 0, 0, 0.80);
-		}
-
-		button:hover {
-			background-image: -webkit-linear-gradient(#BDC2D0 0%, #656874 100%);
-			background-image: -o-linear-gradient(#BDC2D0 0%, #656874 100%);
-			background-image: linear-gradient(#BDC2D0 0%, #656874 100%);
-		}
-
-		img {
-			border: 1px solid transparent;
-		}
-
-		img:hover {
-			border: 1px solid #ddd;
-		}
-
-		#loupe {
-			/*overflow: auto;*/
-			height: 46%;
-		}
-
-		#big {
-			/*width: 590px;
-			height: 390px;
-			*/
-			/*max-height: 590px;
-			max-width: 590px;*/
-		}
-
-		.dotted-border {
-			width: 360px;
-			height: 230px;
-			border: 2px dotted #676B78;
-			border-radius: 4px;
-		}
-
-		.txt-drag-your-photos-here {
-			font-size: 15px;
-			color: #898D9B;
-		}
-
-		#sliders {
-			right: 0px;
-			width: 200px;
-			position: absolute;
-			background:rgba(0, 0, 0, 0.30);
-		}
-
-		#preview {
-			/* Film Strip */
-			/*display: flex;
-			overflow: scroll;*/
-
-			height: 39%;
-			width: 100%;
-
-			position: absolute;
-			overflow: auto;
-			bottom: 0;
-			border-top: 1px solid #999;
-			transition: 350ms ease-out height;
-			background: #333;
-			z-index: 2;
-		}
-
-		#preview > figure > img {
-			transition: height 350ms ease-out;
-		}
-
-		#preview-slider {
-			display: block;
-			width: 100%;
-			height: 8px;
-			background: #000;
-			cursor: ns-resize;
-		}
-
-	</style>
-
 	<script src="lightbroom.js"></script>
 	<script src="transfer-image.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -115,6 +115,15 @@
 		.nofilter img {
 			width: 100%;
 		}
+		
+		.selected-effect {
+			border: 2px solid #ccc;
+			box-sizing: border-box;
+		}
+		
+		.selected-effect:hover {
+			border: 2px solid #fff;
+		}
 
 		#filters {
 			display: flex;
@@ -159,7 +168,7 @@
 		}
 
 		img {
-			border: 1px solid transparent;;
+			border: 1px solid transparent;
 		}
 
 		img:hover {

--- a/index.html
+++ b/index.html
@@ -67,8 +67,9 @@
 
 		<div id="preview">
 			<div id="preview-slider"></div>
-			<!-- film strip here -->
+			<div id="filmstrip"></div>
 		</div>
+
 	</div>
 	<script src="lightbroom.js"></script>
 	<script src="transfer-image.js"></script>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@ for some reason this is causing strange layout issues...
 			
 			<button onclick="removeSelection()">Remove</button>
 			<button onclick="clearThumbnails()">Remove All</button>
+			
+			<button onclick="selectAll()">Select All</button>
 		</div>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
 		<div id="big">
 
 		</div>
+	</div>
 
-		<div id="preview">
-			<!-- film strip here -->
-			<div id="preview-slider" onclick="togglePreviewSlider()"></div>
-		</div>
+	<div id="preview">
+		<div id="preview-slider"></div>
+		<!-- film strip here -->
 	</div>
 
 	<!--

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div id="topbar">
 		<!-- toolbar here -->
 		<!--<button>browse photos here.....</button>-->
-		<span class="txt-drag-your-photos-here">
+		<span id="save-options" class="txt-drag-your-photos-here">
 			<button onclick="saveImage()">Save Image</button>
 			<button onclick="outputFolder()">Output directory</button> <span id="saveTo"></span>
 			<button onclick="saveAll()">Save All Images</button>
@@ -72,7 +72,19 @@
             box-shadow: 0px 1px 0px 0px #24272D;
             width: 100%;
             height: 50px;
+			display: flex;
         }
+
+		#save-options {
+			transition: width 400ms ease-out;
+			width: 90px;
+			display: inline-block;
+			overflow: hidden;
+		}
+
+		#save-options:hover {
+			width: 670px;
+		}
 
 		.pic {
 			max-height: 320px;
@@ -119,6 +131,9 @@
 			border-radius: 4px;
 			color: #eaeaea;
             font-size: 13px;
+
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		.effect {

--- a/index.html
+++ b/index.html
@@ -10,33 +10,38 @@
 	<script src="node_modules/exif-js/exif.js"></script>
 
     <div id="topbar">
-        <div id="toolbar">
-			<!--<button>browse photos here.....</button>-->
-			<span class="txt-drag-your-photos-here">
-				<button onclick="saveImage()">Save Image</button>
-				<br/>
+		<!-- toolbar here -->
+		<!--<button>browse photos here.....</button>-->
+		<span class="txt-drag-your-photos-here">
+			<button onclick="saveImage()">Save Image</button>
+			<button onclick="outputFolder()">Output directory</button> <span id="saveTo"></span>
+			<button onclick="saveAll()">Save All Images</button>
+			Long side: <input id="longside" type="text" size="5" value="" style="background: none; color: #fff;" placeholder="auto"/>
 
-				<button onclick="outputFolder()">Output directory</button> <span id="saveTo"></span>
-				<button onclick="saveAll()">Save All Images</button>
-				Long side: <input id="longside" type="text" size="5" value="" style="background: none; color: #fff;" placeholder="auto"/>
+			<span id="status"></span>
+			<!--[ Select Target Folder ] [ Output Size ][ Output Suffix ]-->
+		</span>
 
-				<span id="status"></span>
-				<!--[ Select Target Folder ] [ Output Size ][ Output Suffix ]-->
-			</span>
-		</div>
+		<button onclick="togglePreviewSlider()">v</button>
+		<button onclick="sizeThumbnails(120)">S</button>
+		<button onclick="sizeThumbnails(240)">M</button>
+		<button onclick="sizeThumbnails(800)">L</button>
 
     </div>
+
 	<div id="filters"></div>
+
 	<div id="peeks"></div>
 
 	<div id="sliders"></div>
 
 	<div id="drop">
-		
 		<div id="big"></div>
 
-		<br/>
-		<div id="preview"></div>
+		<div id="preview">
+			<!-- film strip here -->
+			<div id="preview-slider" onclick="togglePreviewSlider()"></div>
+		</div>
 	</div>
 
 	<!--
@@ -61,19 +66,20 @@
             margin: 0;
             padding: 0;
 		}
-        
+
         #topbar {
             background: #555862;
             box-shadow: 0px 1px 0px 0px #24272D;
             width: 100%;
             height: 50px;
         }
-        
+
 		.pic {
 			max-height: 320px;
 			max-width: 320px;
 
 			margin: 5px;
+			border-radius: 4px;
 
 			float: left;
 		}
@@ -92,7 +98,6 @@
 
 		.nofilter img {
 			width: 100%;
-            border-radius: 4px;
 		}
 
 		#filters {
@@ -122,7 +127,6 @@
 			text-align: center;
 			font-weight: bold;
 			display: block;
-
 		}
 
 		button:active {
@@ -136,7 +140,7 @@
 		}
 
 		img {
-			border: 1px solid transparent;
+			border: 1px solid transparent;;
 		}
 
 		img:hover {
@@ -174,292 +178,31 @@
 			overflow: scroll;*/
 
 			height: 39%;
+			width: 100%;
+
 			position: absolute;
 			overflow: auto;
 			bottom: 0;
 			border-top: 1px solid #999;
+			transition: 350ms ease-out height;
+			background: #333;
+		}
+
+		#preview > figure {
+			transition: 350ms ease-out all;
+		}
+
+		#preview-slider {
+			display: block;
+			width: 100%;
+			height: 8px;
+			background: #000;
+			cursor: ns-resize;
 		}
 
 	</style>
 
-	<script>
-
-		var opener = new ImageOpener(processImage);
-		var count = 0;
-		var maxLength = 240;
-
-		var preview = document.getElementById('preview');
-		var filters = document.getElementById('filters');
-		var peeks = document.getElementById('peeks');
-		var big = document.getElementById('big'), bigimg;
-
-		var styles = [
-			"Nofilter",
-			"Aden",
-			"Inkwell",
-			"Perpetua",
-			"Reyes",
-			"Gingham",
-			"Toaster",
-			"Walden",
-			"Hudson",
-			"Earlybird",
-			"Mayfair",
-			"Lofi",
-			"_1977",
-			"Brooklyn",
-			"Xpro2",
-			"Nashville",
-			"Lark",
-			"Moon",
-			"Clarendon",
-			"Willow"
-		];
-
-		var currentStyle = 'nofilter';
-		var saved;
-		var filterItems = new Map();
-
-		var filenames;
-		var selectedPhoto;
-
-		var photos = new PhotoList();
-
-		styles.forEach( function(s) {
-			var div = document.createElement('div');
-
-			var b = document.createElement('b');
-			b.className = 'effect';
-			
-
-			b.onclick = function() {
-				saved = currentStyle;
-				switchStyle(s);
-			}
-
-			b.onmouseover = function() {
-				saved = currentStyle;
-				switchStyle(s);
-			}
-
-			b.onmouseout = function() {
-				switchStyle(saved);
-			}
-
-			div.appendChild(b);
-
-			var figure = document.createElement('figure');
-			b.appendChild(figure);
-            b.innerHTML += s;
-
-			filterItems.set(s, div);
-			filters.appendChild(div);
-		} )
-
-
-		function switchStyle(s) {
-			var old = currentStyle;
-
-			var pics = document.querySelectorAll('.pic, .big')
-
-			for (var i = 0; i < pics.length; i ++) {
-				var p = pics[i];
-				p.classList.remove(old);
-				p.classList.add(s);
-			}
-
-			currentStyle = s;
-		}
-
-		var x = 0;
-
-		var tmp;
-		var save;
-
-		var img = big;
-		var lasty;
-
-		img.onmouseover = function(e) {
-			save = currentStyle;
-		}
-
-		img.onmousemove = function(e) {
-			// code here to reimplement scrubbing behaviour
-			// (potatoe prototype6)
-		}
-
-		img.onmouseout = function(e) {
-			if (!bigimg) return;
-			tmp = bigimg.classList[1];
-			bigimg.classList.remove(tmp);
-			bigimg.classList.add(currentStyle);
-		}
-
-		img.onmousedown = function(e) {
-			save = bigimg.classList[1];
-			switchStyle(save);
-		}
-
-		function previewBig(img, photo, orientation) {
-			selectedPhoto = photo;
-
-			img = scaleImage(img, 590, orientation);
-
-			var child;
-			while (child = big.childNodes[0]) {
-				child.remove();
-			}
-
-			n = document.createElement('figure');
-			n.appendChild(img.cloneNode());
-			n.classList.add('big');
-			n.classList.add(currentStyle);
-			bigimg = n;
-
-			big.appendChild(n);
-
-			img = scaleImage(img, maxLength);
-
-			styles.forEach(function(s) {
-				var m = filterItems.get(s).querySelector('figure');
-
-				while (child = m.firstChild) {
-					child.remove();
-				}
-
-				m.appendChild(img.cloneNode());
-
-				while (m.classList.length) {
-					m.classList.remove(m.classList[0]);
-				}
-				m.classList.add('peek');
-				m.classList.add(s);
-
-			});
-
-		}
-
-		function scaleImage(img, maxLength, orientation) {
-			var canvas = getCanvas(img, maxLength, orientation);
-
-			var image = new Image();
-			image.src = canvas.toDataURL("image/png");
-
-			return image;
-		}
-
-		function getCanvas(img, maxLength, orientation) {
-			var imgWidth = img.naturalWidth;
-			var imgHeight = img.naturalHeight;
-
-			// can rotate here....
-
-			var scale = imgWidth > imgHeight ? maxLength / imgWidth : maxLength / imgHeight;
-
-			var canvas = document.createElement('canvas');
-			var ctx = canvas.getContext('2d');
-
-			var targetWidth = imgWidth * scale;
-			var targetHeight = imgHeight * scale;
-
-			canvas.width = targetWidth;
-			canvas.height = targetHeight;
-			if (orientation > 4) {
-				canvas.width = targetHeight;
-				canvas.height = targetWidth;
-			}
-
-			var width = targetWidth;
-			var height = targetHeight;
-
-			switch (orientation) {
-				case 2:
-					// horizontal flip
-					ctx.translate(width, 0);
-					ctx.scale(-1, 1);
-					break;
-				case 3:
-					// 180° rotate left
-					ctx.translate(width, height);
-					ctx.rotate(Math.PI);
-					break;
-				case 4:
-					// vertical flip
-					ctx.translate(0, height);
-					ctx.scale(1, -1);
-					break;
-				case 5:
-					// vertical flip + 90 rotate right
-					ctx.rotate(0.5 * Math.PI);
-					ctx.scale(1, -1);
-					break;
-				case 6:
-					// 90° rotate right
-					ctx.rotate(0.5 * Math.PI);
-					ctx.translate(0, -height);
-					break;
-				case 7:
-					// horizontal flip + 90 rotate right
-					ctx.rotate(0.5 * Math.PI);
-					ctx.translate(width, -height);
-					ctx.scale(-1, 1);
-					break;
-				case 8:
-					// 90° rotate left
-					ctx.rotate(-0.5 * Math.PI);
-					ctx.translate(-width, 0);
-					break;
-			}
-
-			ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
-
-			return canvas;
-		}
-
-		// var filenames = [];
-		// filenames.push(files[i].path);
-		// localStorage.lastLoad = JSON.stringify(filenames);
-		// console.log('Got Files', filenames);
-
-		function processImage(oImg, path, i) {
-			EXIF.getData(oImg, function() {
-				var exif = EXIF.getAllTags(oImg);
-				processImage2(oImg, path, i, exif);
-			});
-		}
-
-		function processImage2(oImg, path, i, exif) {
-			var orientation = exif.Orientation;
-			var photo = new Photo(path, oImg, orientation);
-			photos.add( photo );
-
-			// console.log('process image');
-
-			// var canvas = getCanvas(img, 550);
-			// inlineSVGImg(canvas.toDataURL(), canvas.width, canvas.height);
-
-
-
-			if (photos.count() == 1) {
-				previewBig(oImg, photo, orientation);
-			}
-
-			var img = scaleImage(oImg, 390, orientation);
-
-			var figure = document.createElement('figure');
-			figure.classList.add('pic');
-			figure.classList.add(currentStyle);
-			figure.appendChild(img);
-
-			preview.appendChild(figure);
-
-			img.onclick = function() {
-				previewBig(oImg, photo, orientation);
-			}
-
-		}
-
-	</script>
+	<script src="lightbroom.js"></script>
 	<script src="transfer-image.js"></script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -22,21 +22,37 @@
 			<!--[ Select Target Folder ] [ Output Size ][ Output Suffix ]-->
 		</span>
 
-		<button onclick="togglePreviewSlider()">v</button>
-		<button onclick="sizeThumbnails(120)">S</button>
-		<button onclick="sizeThumbnails(240)">M</button>
-		<button onclick="sizeThumbnails(360)">L</button>
+		<div>
+			Filmstrip:
+			<button onclick="sizeThumbnails(120)">S</button>
+			<button onclick="sizeThumbnails(240)">M</button>
+			<button onclick="sizeThumbnails(360)">L</button>
+
+		</div>
+
+		<div class="txt-drag-your-photos-here" style="bottom: 0">
+			<button onclick="toggleEffects()">Effects</button>
+			Drag photos into the app to start.
+			<button onclick="clearThumbnails()">Clear</button>
+		</div>
 
     </div>
 
 	<div id="filters"></div>
 
-	<div id="peeks"></div>
+	<!--
+		NOT IN USE
+		<div id="peeks">
+		</div>
+	-->
 
 	<div id="sliders"></div>
 
 	<div id="drop">
-		<div id="big"></div>
+		<button onclick="togglePreviewSlider()" style="float:right;">v</button>
+		<div id="big">
+
+		</div>
 
 		<div id="preview">
 			<!-- film strip here -->
@@ -131,6 +147,7 @@
             box-shadow: 0px 1px 0px 0px rgba(255,255,255,0.30);
             padding: 14px;
             font-size: 13px;
+			transition: height 250ms;
 		}
 
 		button {
@@ -213,6 +230,7 @@
 			border-top: 1px solid #999;
 			transition: 350ms ease-out height;
 			background: #333;
+			z-index: 2;
 		}
 
 		#preview > figure > img {

--- a/index.html
+++ b/index.html
@@ -18,13 +18,14 @@ for some reason this is causing strange layout issues...
 		initial potatoe prototype from http://jabtunes.com/labs/potatoe/ series
 
 		TODO
-		- Remove images
 		- Remember last effect, last output settings (resolution)
 
 		DONE
 		1. Photo rotation (transform in canvas, pass css transform)
 		2. Output size (easy, can use css for now)
 		3. Save last target folder
+		4. Select and Remove images
+		5. Resize film strip thumbnails
 	-->
 
 
@@ -51,8 +52,9 @@ for some reason this is causing strange layout issues...
 		<div class="txt-drag-your-photos-here" style="bottom: 0">
 			<button onclick="toggleEffects()">Effects</button>
 			Drag photos into the app to start.
-			<button onclick="clearThumbnails()">Clear</button>
+			
 			<button onclick="removeSelection()">Remove</button>
+			<button onclick="clearThumbnails()">Remove All</button>
 		</div>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 		<button onclick="togglePreviewSlider()">v</button>
 		<button onclick="sizeThumbnails(120)">S</button>
 		<button onclick="sizeThumbnails(240)">M</button>
-		<button onclick="sizeThumbnails(800)">L</button>
+		<button onclick="sizeThumbnails(360)">L</button>
 
     </div>
 
@@ -88,11 +88,10 @@
 		}
 
 		.pic {
-			max-height: 320px;
-			max-width: 320px;
+			/*max-height: 320px;
+			max-width: 320px;*/
 
 			margin: 5px;
-
 			float: left;
 		}
 
@@ -115,12 +114,12 @@
 		.nofilter img {
 			width: 100%;
 		}
-		
+
 		.selected-effect {
 			border: 2px solid #ccc;
 			box-sizing: border-box;
 		}
-		
+
 		.selected-effect:hover {
 			border: 2px solid #fff;
 		}
@@ -216,8 +215,8 @@
 			background: #333;
 		}
 
-		#preview > figure {
-			transition: 350ms ease-out all;
+		#preview > figure > img {
+			transition: height 350ms ease-out;
 		}
 
 		#preview-slider {

--- a/index.html
+++ b/index.html
@@ -48,8 +48,9 @@
 
 	<div id="sliders"></div>
 
-	<div id="drop">
+	<div id="loupe">
 		<button onclick="togglePreviewSlider()" style="float:right;">v</button>
+
 		<div id="big">
 
 		</div>
@@ -122,11 +123,6 @@
 			margin: 2px;
 		}
 
-		.big {
-			max-height: 590px;
-			max-width: 590px;
-		}
-
 		.nofilter img {
 			width: 100%;
 		}
@@ -191,10 +187,17 @@
 			border: 1px solid #ddd;
 		}
 
+		#loupe {
+			/*overflow: auto;*/
+			height: 46%;
+		}
+
 		#big {
-			display: inline-block;
-			width: 590px;
+			/*width: 590px;
 			height: 390px;
+			*/
+			/*max-height: 590px;
+			max-width: 590px;*/
 		}
 
 		.dotted-border {

--- a/index.html
+++ b/index.html
@@ -56,21 +56,19 @@
 
 	<div id="sliders"></div>
 
-	<div>
-		<div id="loupe">
-			<button onclick="togglePreviewSlider()" style="float:right;">v</button>
+	<div id="loupe">
+		<button onclick="togglePreviewSlider()" style="float:right;">v</button>
 
-			<div id="big">
+		<div id="big">
 
-			</div>
 		</div>
-
-		<div id="preview">
-			<div id="preview-slider"></div>
-			<div id="filmstrip"></div>
-		</div>
-
 	</div>
+
+	<div id="preview">
+		<div id="preview-slider"></div>
+		<div id="filmstrip"></div>
+	</div>
+
 	<script src="lightbroom.js"></script>
 	<script src="transfer-image.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,9 @@
+<!--<!DOCTYPE html>
+for some reason this is causing strange layout issues...
+-->
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Lightbroom Preview</title>
         <link href='https://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic' rel='stylesheet' type='text/css'>
 	</head>
@@ -48,6 +52,7 @@
 			<button onclick="toggleEffects()">Effects</button>
 			Drag photos into the app to start.
 			<button onclick="clearThumbnails()">Clear</button>
+			<button onclick="removeSelection()">Remove</button>
 		</div>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 			font-size: 13px;
             margin: 0;
             padding: 0;
+			outline: none;
 		}
 
         #topbar {
@@ -91,9 +92,12 @@
 			max-width: 320px;
 
 			margin: 5px;
-			border-radius: 4px;
 
 			float: left;
+		}
+
+		.pic img, .effect img {
+			border-radius: 4px;
 		}
 
 		.peek {

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -6,6 +6,9 @@ body {
 	margin: 0;
 	padding: 0;
 	outline: none;
+
+	display: flex;
+	flex-direction: column;
 }
 
 #topbar {
@@ -111,8 +114,9 @@ img:hover {
 }
 
 #loupe {
-	/*overflow: auto;*/
-	height: 46%;
+	/*height: 46%;*/
+	flex: 1;
+	overflow: auto;
 }
 
 #big {
@@ -143,8 +147,6 @@ img:hover {
 }
 
 #preview {
-	/*overflow: scroll;*/
-
 	height: 39%;
 	width: 100%;
 
@@ -165,8 +167,8 @@ img:hover {
 }
 
 #filmstrip {
-	width: 100%;
-	height: 100%;
+	/*width: 100%;
+	height: 100%;*/
 	flex: 1;
 	overflow: auto;
 }

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -11,7 +11,8 @@ body {
 	flex-direction: column;
 }
 
-html {
+html, body {
+	height: 100%;
 }
 
 #topbar {
@@ -33,17 +34,7 @@ html {
 	width: 670px;
 }
 
-.pic {
-	/*max-height: 320px;
-	max-width: 320px;*/
 
-	margin: 5px;
-	float: left;
-}
-
-.pic img, .effect img {
-	border-radius: 4px;
-}
 
 .peek {
 	max-height: 120px;
@@ -165,7 +156,7 @@ img:hover {
 	flex-direction: column;
 }
 
-#preview > figure > img {
+#filmstrip > figure > img {
 	transition: height 350ms ease-out;
 }
 
@@ -174,6 +165,10 @@ img:hover {
 	height: 100%;*/
 	flex: 1;
 	overflow: auto;
+	
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
 }
 
 #preview-slider {
@@ -186,4 +181,65 @@ img:hover {
 
 .no-transition {
 	transition: none !important;
+}
+
+.checkbox {
+	/*background: deeppink;*/
+	/*width: 40px;
+	height: 40px;*/
+	position: absolute;
+	right: 0;
+	/*display: inline-block;*/
+	z-index: 10;
+	/*opacity: 0.2;*/
+	
+}
+
+.checkbox label:hover {
+	opacity: 1;
+	background: rgba(0,0,0,0.50);
+}
+
+.checkbox label {
+	display: inline-block;
+	position: relative;
+	font-size: 2em;
+	vertical-align: center;
+	text-align: center;
+	color: rgba(255, 255, 255, 0.5);
+	cursor: pointer;
+	transition: color 0.3s;
+	border: 2px solid rgba(255, 255, 255, 1);
+	width: 1.3em;
+	height: 1.3em;
+	opacity: 0.2;
+	border-radius: 50%;
+	transition: opacity 0.2s, border-radius 0.2s, border 0.25s;
+	margin: 4px;
+}
+
+.checkbox input[type="checkbox"],
+.checkbox input[type="radio"] {
+	display: none;
+}
+
+.checkbox .checked {
+	opacity: 1;
+	color: rgba(255, 255, 255, 1);
+	border: 2px solid rgba(255, 255, 255, 0.1);
+	border-radius: 0;
+}
+
+#filmstrip > div {
+	display: inline-block;
+	margin: 5px;
+	position: relative;
+}
+
+.pic {
+	margin: 0;
+}
+
+.pic img, .effect img {
+	border-radius: 4px;
 }

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -143,26 +143,33 @@ img:hover {
 }
 
 #preview {
-	/* Film Strip */
-	/*display: flex;
-	overflow: scroll;*/
+	/*overflow: scroll;*/
 
 	height: 39%;
 	width: 100%;
 
-	position: absolute;
-	overflow: auto;
+	/*position: absolute;
+	overflow: auto;*/
 	bottom: 0;
 	border-top: 1px solid #999;
 	transition: 350ms ease-out height;
-	background: #333;
+	/*background: #333;*/
 	z-index: 2;
+	
+	display: flex;
+	flex-direction: column;
 }
 
 #preview > figure > img {
 	transition: height 350ms ease-out;
 }
 
+#filmstrip {
+	width: 100%;
+	height: 100%;
+	flex: 1;
+	overflow: auto;
+}
 #preview-slider {
 	display: block;
 	width: 100%;

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -11,6 +11,9 @@ body {
 	flex-direction: column;
 }
 
+html {
+}
+
 #topbar {
 	background: #555862;
 	box-shadow: 0px 1px 0px 0px #24272D;
@@ -172,10 +175,15 @@ img:hover {
 	flex: 1;
 	overflow: auto;
 }
+
 #preview-slider {
 	display: block;
 	width: 100%;
 	height: 8px;
 	background: #000;
 	cursor: ns-resize;
+}
+
+.no-transition {
+	transition: none !important;
 }

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -1,0 +1,172 @@
+body {
+	font-family: 'Lato', sans-serif;
+	background-color: #333740;
+	color: #ddd;
+	font-size: 13px;
+	margin: 0;
+	padding: 0;
+	outline: none;
+}
+
+#topbar {
+	background: #555862;
+	box-shadow: 0px 1px 0px 0px #24272D;
+	width: 100%;
+	height: 50px;
+	display: flex;
+}
+
+#save-options {
+	transition: width 400ms ease-out;
+	width: 90px;
+	display: inline-block;
+	overflow: hidden;
+}
+
+#save-options:hover {
+	width: 670px;
+}
+
+.pic {
+	/*max-height: 320px;
+	max-width: 320px;*/
+
+	margin: 5px;
+	float: left;
+}
+
+.pic img, .effect img {
+	border-radius: 4px;
+}
+
+.peek {
+	max-height: 120px;
+	max-width: 120px;
+	float: left;
+	margin: 2px;
+}
+
+.nofilter img {
+	width: 100%;
+}
+
+.selected-effect {
+	border: 2px solid #ccc;
+	box-sizing: border-box;
+}
+
+.selected-effect:hover {
+	border: 2px solid #fff;
+}
+
+#filters {
+	display: flex;
+	overflow: scroll;
+	background-color: #23262C;
+	box-shadow: 0px 1px 0px 0px rgba(255,255,255,0.30);
+	padding: 14px;
+	font-size: 13px;
+	transition: height 250ms;
+}
+
+button {
+	font-family: 'Lato', sans-serif;
+	padding: 10px;
+	margin: 4px 4px 14px 4px;
+	background-image: linear-gradient(-180deg, #7B7E87 0%, #555862 100%);
+	border: 1px solid #292B31;
+	box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.30), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.60);
+	border-radius: 4px;
+	color: #eaeaea;
+	font-size: 13px;
+
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.effect {
+	width: 130px;
+	display: block;
+	text-align: center;
+	font-weight: bold;
+	display: block;
+}
+
+button:active {
+	box-shadow: 0px 1px 1px 0px rgba(255, 255, 255, 0.30), inset 0px 0px 4px 0px rgba(0, 0, 0, 0.80);
+}
+
+button:hover {
+	background-image: -webkit-linear-gradient(#BDC2D0 0%, #656874 100%);
+	background-image: -o-linear-gradient(#BDC2D0 0%, #656874 100%);
+	background-image: linear-gradient(#BDC2D0 0%, #656874 100%);
+}
+
+img {
+	border: 1px solid transparent;
+}
+
+img:hover {
+	border: 1px solid #ddd;
+}
+
+#loupe {
+	/*overflow: auto;*/
+	height: 46%;
+}
+
+#big {
+	/*width: 590px;
+	height: 390px;
+	*/
+	/*max-height: 590px;
+	max-width: 590px;*/
+}
+
+.dotted-border {
+	width: 360px;
+	height: 230px;
+	border: 2px dotted #676B78;
+	border-radius: 4px;
+}
+
+.txt-drag-your-photos-here {
+	font-size: 15px;
+	color: #898D9B;
+}
+
+#sliders {
+	right: 0px;
+	width: 200px;
+	position: absolute;
+	background:rgba(0, 0, 0, 0.30);
+}
+
+#preview {
+	/* Film Strip */
+	/*display: flex;
+	overflow: scroll;*/
+
+	height: 39%;
+	width: 100%;
+
+	position: absolute;
+	overflow: auto;
+	bottom: 0;
+	border-top: 1px solid #999;
+	transition: 350ms ease-out height;
+	background: #333;
+	z-index: 2;
+}
+
+#preview > figure > img {
+	transition: height 350ms ease-out;
+}
+
+#preview-slider {
+	display: block;
+	width: 100%;
+	height: 8px;
+	background: #000;
+	cursor: ns-resize;
+}

--- a/lightbroom.css
+++ b/lightbroom.css
@@ -34,8 +34,6 @@ html, body {
 	width: 670px;
 }
 
-
-
 .peek {
 	max-height: 120px;
 	max-width: 120px;
@@ -156,7 +154,7 @@ img:hover {
 	flex-direction: column;
 }
 
-#filmstrip > figure > img {
+#filmstrip img {
 	transition: height 350ms ease-out;
 }
 
@@ -169,6 +167,8 @@ img:hover {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
+	
+	align-content: flex-start;
 }
 
 #preview-slider {

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -156,6 +156,8 @@ function previewBig(img, photo, orientation) {
 		m.classList.add(s);
 
 	});
+	
+	sizeThumbnails(lastThumbnailSize);
 
 }
 
@@ -295,11 +297,19 @@ function togglePreviewSlider() {
 	toggled = (toggled + 1) % 3;
 }
 
+var lastThumbnailSize = 200;
 function sizeThumbnails(size) {
+	lastThumbnailSize = 200;
 	Array.from(document.querySelectorAll('#preview figure')).forEach(
 		d => {
-			d.style.maxWidth =`${size}px`;
-			d.style.maxHeight = `${size}px`;
+			var i = d.querySelector('img');
+			i.style.width = 'auto';
+			// i.style.height =  `100%`;
+			i.style.height =  `${size}px`;
+			// d.style.maxWidth =`${size}px`;
+			// d.style.maxHeight = `${size * 0.67}px`;
+			// d.style.maxHeight = `auto`;
+			// d.style.maxHeight = `${size}px`;
 		}
 	)
 }

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -339,7 +339,30 @@ function toggleEffects() {
 		filters.style.height = '128px';
 		effectsTray = true;
 	}
+}
 
 
+var slider = document.getElementById('preview-slider');
+slider.onmousedown = function() {
 
+	var moved = false;
+
+	var onmove = function(e) {
+		moved = true;
+		var x = window.innerHeight - e.screenY;
+
+		preview.style.height = x + 'px';
+	};
+
+	var onup = function() {
+		if (!moved) {
+			togglePreviewSlider();
+		}
+
+		window.removeEventListener('mousemove', onmove);
+		window.removeEventListener('mouseup', onup);
+	}
+
+	window.addEventListener('mousemove', onmove);
+	window.addEventListener('mouseup', onup);
 }

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -274,19 +274,24 @@ function processImage2(oImg, path, i, exif) {
 	}
 
 }
-
-
-var toggled = false;
+var toggled = 0;
 
 /* Actions */
 function togglePreviewSlider() {
-	if (toggled) {
-		preview.style.height = '10px'; // '300px';
-	} else {
-		preview.style.height = '80%';
+	
+	switch (toggled) {
+		case 0:
+			preview.style.height = '80%';
+			break;
+		case 1:
+			preview.style.height = '300px';
+			break;
+		case 2:
+			preview.style.height = '10px';		
+			break;
 	}
 
-	toggled = !toggled;
+	toggled = (toggled + 1) % 3;
 }
 
 function sizeThumbnails(size) {

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -345,7 +345,6 @@ function toggleEffects() {
 
 var slider = document.getElementById('preview-slider');
 slider.onmousedown = function() {
-
 	var moved = false;
 
 	var onmove = function(e) {
@@ -353,12 +352,16 @@ slider.onmousedown = function() {
 		var x = window.innerHeight - e.screenY;
 
 		preview.style.height = x + 'px';
+		preview.style.transition = 'none';
+		// preview.classList.add('no-transition');
 	};
 
 	var onup = function() {
 		if (!moved) {
 			togglePreviewSlider();
 		}
+		// preview.classList.remove('no-transition');
+		preview.style.transition = '';
 
 		window.removeEventListener('mousemove', onmove);
 		window.removeEventListener('mouseup', onup);

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -322,7 +322,7 @@ function processImage2(oImg, path, i, exif) {
 		cb.onchange();
 		previewBig(oImg, photo, orientation);
 	}
-	
+
 	/*
 		photos.remove(photo);
 		photosDomSync();
@@ -378,21 +378,22 @@ function clearThumbnails() {
 
 function removeSelection() {
 	var proceed = confirm('Remove ' + photos.selection.size + ' photos?');
-	if (!proceed) return; 
+	if (!proceed) return;
 	photos.selection.forEach(photos.remove.bind(photos));
 	photosDomSync();
 }
 
-var toggleggg = false;
+var toggleSelectAll = false;
 
 function selectAll() {
 	// photos.list.forEach(photos.selection.add.bind(photos));
 	// photosDomSync();
-	
+
+	toggleSelectAll = !toggleSelectAll;
+
 	Array.from(document.querySelectorAll('#filmstrip input')).forEach(
 		cb => {
-			toggleggg = !toggleggg;
-			cb.checked = toggleggg;
+			cb.checked = toggleSelectAll;
 			cb.onchange();
 		}
 	)
@@ -400,7 +401,7 @@ function selectAll() {
 
 function photosDomSync() {
 	var dom = Array.from(document.querySelectorAll('[data-path]'))
-	
+
 	dom.forEach( d => {
 		var match = photos.filter(d.dataset.path);
 

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -1,0 +1,299 @@
+'use strict';
+
+var opener = new ImageOpener(processImage);
+var count = 0;
+var maxLength = 240;
+
+var preview = document.getElementById('preview');
+var filters = document.getElementById('filters');
+var peeks = document.getElementById('peeks');
+var big = document.getElementById('big'), bigimg;
+
+var styles = [
+	"Nofilter",
+	"Aden",
+	"Inkwell",
+	"Perpetua",
+	"Reyes",
+	"Gingham",
+	"Toaster",
+	"Walden",
+	"Hudson",
+	"Earlybird",
+	"Mayfair",
+	"Lofi",
+	"_1977",
+	"Brooklyn",
+	"Xpro2",
+	"Nashville",
+	"Lark",
+	"Moon",
+	"Clarendon",
+	"Willow"
+];
+
+var currentStyle = 'nofilter';
+var saved;
+var filterItems = new Map();
+
+var filenames;
+var selectedPhoto;
+
+var photos = new PhotoList();
+
+styles.forEach( function(s) {
+	var div = document.createElement('div');
+
+	var b = document.createElement('b');
+	b.className = 'effect';
+
+
+	b.onclick = function() {
+		saved = currentStyle;
+		switchStyle(s);
+	}
+
+	b.onmouseover = function() {
+		saved = currentStyle;
+		switchStyle(s);
+	}
+
+	b.onmouseout = function() {
+		switchStyle(saved);
+	}
+
+	div.appendChild(b);
+
+	var figure = document.createElement('figure');
+	b.appendChild(figure);
+	b.innerHTML += s;
+
+	filterItems.set(s, div);
+	filters.appendChild(div);
+} )
+
+
+function switchStyle(s) {
+	var old = currentStyle;
+
+	var pics = document.querySelectorAll('.pic, .big')
+
+	for (var i = 0; i < pics.length; i ++) {
+		var p = pics[i];
+		p.classList.remove(old);
+		p.classList.add(s);
+	}
+
+	currentStyle = s;
+}
+
+var x = 0;
+
+var tmp;
+var save;
+
+var img = big;
+var lasty;
+
+img.onmouseover = function(e) {
+	save = currentStyle;
+}
+
+img.onmousemove = function(e) {
+	// code here to reimplement scrubbing behaviour
+	// (potatoe prototype6)
+}
+
+img.onmouseout = function(e) {
+	if (!bigimg) return;
+	tmp = bigimg.classList[1];
+	bigimg.classList.remove(tmp);
+	bigimg.classList.add(currentStyle);
+}
+
+img.onmousedown = function(e) {
+	save = bigimg.classList[1];
+	switchStyle(save);
+}
+
+function previewBig(img, photo, orientation) {
+	selectedPhoto = photo;
+
+	img = scaleImage(img, 590, orientation);
+
+	var child;
+	while (child = big.childNodes[0]) {
+		child.remove();
+	}
+
+	n = document.createElement('figure');
+	n.appendChild(img.cloneNode());
+	n.classList.add('big');
+	n.classList.add(currentStyle);
+	bigimg = n;
+
+	big.appendChild(n);
+
+	img = scaleImage(img, maxLength);
+
+	styles.forEach(function(s) {
+		var m = filterItems.get(s).querySelector('figure');
+
+		while (child = m.firstChild) {
+			child.remove();
+		}
+
+		m.appendChild(img.cloneNode());
+
+		while (m.classList.length) {
+			m.classList.remove(m.classList[0]);
+		}
+		m.classList.add('peek');
+		m.classList.add(s);
+
+	});
+
+}
+
+function scaleImage(img, maxLength, orientation) {
+	var canvas = getCanvas(img, maxLength, orientation);
+
+	var image = new Image();
+	image.src = canvas.toDataURL("image/png");
+
+	return image;
+}
+
+function getCanvas(img, maxLength, orientation) {
+	var imgWidth = img.naturalWidth;
+	var imgHeight = img.naturalHeight;
+
+	// can rotate here....
+
+	var scale = imgWidth > imgHeight ? maxLength / imgWidth : maxLength / imgHeight;
+
+	var canvas = document.createElement('canvas');
+	var ctx = canvas.getContext('2d');
+
+	var targetWidth = imgWidth * scale;
+	var targetHeight = imgHeight * scale;
+
+	canvas.width = targetWidth;
+	canvas.height = targetHeight;
+	if (orientation > 4) {
+		canvas.width = targetHeight;
+		canvas.height = targetWidth;
+	}
+
+	var width = targetWidth;
+	var height = targetHeight;
+
+	switch (orientation) {
+		case 2:
+			// horizontal flip
+			ctx.translate(width, 0);
+			ctx.scale(-1, 1);
+			break;
+		case 3:
+			// 180° rotate left
+			ctx.translate(width, height);
+			ctx.rotate(Math.PI);
+			break;
+		case 4:
+			// vertical flip
+			ctx.translate(0, height);
+			ctx.scale(1, -1);
+			break;
+		case 5:
+			// vertical flip + 90 rotate right
+			ctx.rotate(0.5 * Math.PI);
+			ctx.scale(1, -1);
+			break;
+		case 6:
+			// 90° rotate right
+			ctx.rotate(0.5 * Math.PI);
+			ctx.translate(0, -height);
+			break;
+		case 7:
+			// horizontal flip + 90 rotate right
+			ctx.rotate(0.5 * Math.PI);
+			ctx.translate(width, -height);
+			ctx.scale(-1, 1);
+			break;
+		case 8:
+			// 90° rotate left
+			ctx.rotate(-0.5 * Math.PI);
+			ctx.translate(-width, 0);
+			break;
+	}
+
+	ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+	return canvas;
+}
+
+// var filenames = [];
+// filenames.push(files[i].path);
+// localStorage.lastLoad = JSON.stringify(filenames);
+// console.log('Got Files', filenames);
+
+function processImage(oImg, path, i) {
+	EXIF.getData(oImg, function() {
+		var exif = EXIF.getAllTags(oImg);
+		processImage2(oImg, path, i, exif);
+	});
+}
+
+function processImage2(oImg, path, i, exif) {
+	var orientation = exif.Orientation;
+	var photo = new Photo(path, oImg, orientation);
+	photos.add( photo );
+
+	// console.log('process image');
+
+	// var canvas = getCanvas(img, 550);
+	// inlineSVGImg(canvas.toDataURL(), canvas.width, canvas.height);
+
+
+
+	if (photos.count() == 1) {
+		previewBig(oImg, photo, orientation);
+	}
+
+	var img = scaleImage(oImg, 390, orientation);
+
+	var figure = document.createElement('figure');
+	figure.classList.add('pic');
+	figure.classList.add(currentStyle);
+	figure.appendChild(img);
+
+	preview.appendChild(figure);
+
+	img.onclick = function() {
+		previewBig(oImg, photo, orientation);
+	}
+
+}
+
+
+var toggled = false;
+
+/* Actions */
+function togglePreviewSlider() {
+	if (toggled) {
+		preview.style.height = '10px'; // '300px';
+	} else {
+		preview.style.height = '80%';
+	}
+
+	toggled = !toggled;
+}
+
+function sizeThumbnails(size) {
+	Array.from(document.querySelectorAll('#preview figure')).forEach(
+		d => {
+			d.style.maxWidth =`${size}px`;
+			d.style.maxHeight = `${size}px`;
+		}
+	)
+}

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -156,7 +156,7 @@ function previewBig(img, photo, orientation) {
 		m.classList.add(s);
 
 	});
-	
+
 	sizeThumbnails(lastThumbnailSize);
 
 }
@@ -273,6 +273,8 @@ function processImage2(oImg, path, i, exif) {
 
 	preview.appendChild(figure);
 
+	figure.scrollIntoView(false, 200);
+
 	img.onclick = function() {
 		previewBig(oImg, photo, orientation);
 	}
@@ -290,7 +292,7 @@ function togglePreviewSlider() {
 			preview.style.height = '300px';
 			break;
 		case 2:
-			preview.style.height = '10px';		
+			preview.style.height = '10px';
 			break;
 	}
 

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -120,17 +120,17 @@ img.onmousedown = function(e) {
 	switchStyle(save);
 }
 
-function previewBig(img, photo, orientation) {
+function previewBig(oimg, photo, orientation) {
 	selectedPhoto = photo;
 
-	img = scaleImage(img, 590, orientation);
+	var img = scaleImage(oimg, 590, orientation);
 
 	var child;
 	while (child = big.childNodes[0]) {
 		child.remove();
 	}
 
-	n = document.createElement('figure');
+	var n = document.createElement('figure');
 	n.appendChild(img.cloneNode());
 	n.classList.add('big');
 	n.classList.add(currentStyle);
@@ -138,7 +138,11 @@ function previewBig(img, photo, orientation) {
 
 	big.appendChild(n);
 
+	// img = scaleImage(oimg, maxLength, orientation);
+
 	img = scaleImage(img, maxLength);
+
+	img.onload = () => {
 
 	styles.forEach(function(s) {
 		var m = filterItems.get(s).querySelector('figure');
@@ -156,6 +160,8 @@ function previewBig(img, photo, orientation) {
 		m.classList.add(s);
 
 	});
+
+	}
 
 }
 

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -277,7 +277,7 @@ function processImage2(oImg, path, i, exif) {
 	figure.classList.add(currentStyle);
 	figure.appendChild(img);
 
-	preview.appendChild(figure);
+	filmstrip.appendChild(figure);
 
 	figure.scrollIntoView(false, 200);
 

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -59,7 +59,7 @@ function setup() {
 			b.querySelector('img').classList.add('selected-effect');
 
 			saved = currentStyle;
-			switchStyle(s);
+			switchStyle(s, true);
 		}
 
 		b.onmouseover = function() {
@@ -88,33 +88,39 @@ function setup() {
 	var tmp;
 	var save;
 
-	var img = big;
+	// var img = big;
 
-	img.onmouseover = function(e) {
-		save = currentStyle;
-	}
+	// img.onmouseover = function(e) {
+	// 	save = currentStyle;
+	// }
 
-	img.onmousemove = function(e) {
-		// code here to reimplement scrubbing behaviour
-		// (potatoe prototype6)
-	}
+	// img.onmousemove = function(e) {
+	// 	// code here to reimplement scrubbing behaviour
+	// 	// (potatoe prototype6)
+	// }
 
-	img.onmouseout = function(e) {
-		if (!bigimg) return;
-		tmp = bigimg.classList[1];
-		bigimg.classList.remove(tmp);
-		bigimg.classList.add(currentStyle);
-	}
+	// img.onmouseout = function(e) {
+	// 	if (!bigimg) return;
+	// 	tmp = bigimg.classList[1];
+	// 	bigimg.classList.remove(tmp);
+	// 	bigimg.classList.add(currentStyle);
+	// }
 
-	img.onmousedown = function(e) {
-		save = bigimg.classList[1];
-		switchStyle(save);
-	}
+	// img.onmousedown = function(e) {
+	// 	save = bigimg.classList[1];
+	// 	switchStyle(save);
+	// }
 }
 
 
-function switchStyle(s) {
+function switchStyle(s, commit) {
 	var old = currentStyle;
+
+	// photos.selection.forEach( p => {
+	// 	p.effect = s;
+	// });
+
+	// photosDomSync();
 
 	var pics = document.querySelectorAll('.pic, .big')
 
@@ -362,23 +368,34 @@ function sizeThumbnails(size) {
 }
 
 function clearThumbnails() {
+	var proceed = confirm('Remove all photos?');
+	if (!proceed) return;
 	photos.empty();
 	photosDomSync();
 }
 
 function removeSelection() {
+	var proceed = confirm('Remove ' + photos.selection.size + ' photos?');
+	if (!proceed) return; 
 	photos.selection.forEach(photos.remove.bind(photos));
 	photosDomSync();
 }
 
 function photosDomSync() {
-	// remove
-	Array.from(document.querySelectorAll('[data-path]')).forEach( d => {
-		var exist = photos.exists(d.dataset.path);
-		if (! exist ) {
-			d.remove();
+	var dom = Array.from(document.querySelectorAll('[data-path]'))
+	
+	dom.forEach( d => {
+		var match = photos.filter(d.dataset.path);
+
+		// remove
+		if (! match.length ) {
+			return d.remove();
 		}
-	} )
+
+		// update
+		var img = d.querySelector('.pic');
+		img.className = 'pic ' + match[0].effect;
+	} );
 }
 
 var effectsTray = true;
@@ -392,7 +409,6 @@ function toggleEffects() {
 		effectsTray = true;
 	}
 }
-
 
 var slider = document.getElementById('preview-slider');
 slider.onmousedown = function() {

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -282,7 +282,6 @@ function processImage2(oImg, path, i, exif) {
 	figure.scrollIntoView(false, 200);
 
 	img.onclick = function() {
-		togglePreviewSlider(1);
 		previewBig(oImg, photo, orientation);
 	}
 

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -157,8 +157,6 @@ function previewBig(img, photo, orientation) {
 
 	});
 
-	sizeThumbnails(lastThumbnailSize);
-
 }
 
 function scaleImage(img, maxLength, orientation) {
@@ -276,14 +274,18 @@ function processImage2(oImg, path, i, exif) {
 	figure.scrollIntoView(false, 200);
 
 	img.onclick = function() {
+		togglePreviewSlider(1);
 		previewBig(oImg, photo, orientation);
 	}
+
+	sizeThumbnails(lastThumbnailSize);
 
 }
 var toggled = 0;
 
 /* Actions */
-function togglePreviewSlider() {
+function togglePreviewSlider(x) {
+	toggled =  x !== undefined ? x : toggled;
 	switch (toggled) {
 		case 0:
 			preview.style.height = '80%';
@@ -314,4 +316,24 @@ function sizeThumbnails(size) {
 			// d.style.maxHeight = `${size}px`;
 		}
 	)
+}
+
+function clearThumbnails() {
+	photos.empty();
+	location.reload();
+}
+
+var effectsTray = true;
+
+function toggleEffects() {
+	if (effectsTray) {
+		filters.style.height = '0px';
+		effectsTray = false;
+	} else {
+		filters.style.height = '128px';
+		effectsTray = true;
+	}
+
+
+
 }

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -83,10 +83,10 @@ function setup() {
 
 	// setup big image preview
 
-	var x = 0;
+	// var x = 0;
 
-	var tmp;
-	var save;
+	// var tmp;
+	// var save;
 
 	// var img = big;
 
@@ -318,6 +318,8 @@ function processImage2(oImg, path, i, exif) {
 	figure.scrollIntoView(false, 200);
 
 	img.onclick = function() {
+		cb.checked = !cb.checked;
+		cb.onchange();
 		previewBig(oImg, photo, orientation);
 	}
 	

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -49,6 +49,10 @@ styles.forEach( function(s) {
 
 
 	b.onclick = function() {
+		var last = document.querySelector('.selected-effect');
+		if (last) last.classList.remove('selected-effect');
+		b.querySelector('img').classList.add('selected-effect');
+
 		saved = currentStyle;
 		switchStyle(s);
 	}
@@ -254,8 +258,6 @@ function processImage2(oImg, path, i, exif) {
 	// var canvas = getCanvas(img, 550);
 	// inlineSVGImg(canvas.toDataURL(), canvas.width, canvas.height);
 
-
-
 	if (photos.count() == 1) {
 		previewBig(oImg, photo, orientation);
 	}
@@ -278,7 +280,6 @@ var toggled = 0;
 
 /* Actions */
 function togglePreviewSlider() {
-	
 	switch (toggled) {
 		case 0:
 			preview.style.height = '80%';

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -2,7 +2,9 @@
 
 var opener = new ImageOpener(processImage);
 var count = 0;
-var maxLength = 240;
+var MAX_EFFECT_PREVIEW_LENGTH = 240;
+var MAX_BIG_PREVIEW_LENGTH = 1600; // || 590;
+var FILMSTRIP_THUMBNAIL_LENGTH = 390;;
 
 var preview = document.getElementById('preview');
 var filters = document.getElementById('filters');
@@ -123,7 +125,7 @@ img.onmousedown = function(e) {
 function previewBig(oimg, photo, orientation) {
 	selectedPhoto = photo;
 
-	var img = scaleImage(oimg, 590, orientation);
+	var img = scaleImage(oimg, MAX_BIG_PREVIEW_LENGTH, orientation);
 
 	var child;
 	while (child = big.childNodes[0]) {
@@ -140,7 +142,7 @@ function previewBig(oimg, photo, orientation) {
 
 	// img = scaleImage(oimg, maxLength, orientation);
 
-	img = scaleImage(img, maxLength);
+	img = scaleImage(img, MAX_EFFECT_PREVIEW_LENGTH);
 
 	img.onload = () => {
 
@@ -268,7 +270,7 @@ function processImage2(oImg, path, i, exif) {
 		previewBig(oImg, photo, orientation);
 	}
 
-	var img = scaleImage(oImg, 390, orientation);
+	var img = scaleImage(oImg, FILMSTRIP_THUMBNAIL_LENGTH, orientation);
 
 	var figure = document.createElement('figure');
 	figure.classList.add('pic');

--- a/lightbroom.js
+++ b/lightbroom.js
@@ -383,6 +383,21 @@ function removeSelection() {
 	photosDomSync();
 }
 
+var toggleggg = false;
+
+function selectAll() {
+	// photos.list.forEach(photos.selection.add.bind(photos));
+	// photosDomSync();
+	
+	Array.from(document.querySelectorAll('#filmstrip input')).forEach(
+		cb => {
+			toggleggg = !toggleggg;
+			cb.checked = toggleggg;
+			cb.onchange();
+		}
+	)
+}
+
 function photosDomSync() {
 	var dom = Array.from(document.querySelectorAll('[data-path]'))
 	

--- a/photo.js
+++ b/photo.js
@@ -17,7 +17,7 @@ PhotoList.prototype.add = function(photo) {
 PhotoList.prototype.remove = function(photo) {
 	var i = this.list.indexOf(photo);
 	this.list.splice(i, 1);
-	
+
 	this.selection.delete(photo);
 	this.save();
 }
@@ -62,6 +62,8 @@ PhotoList.prototype.load = function() {
 PhotoList.prototype.empty = function() {
 	this.list = [];
 	this.save();
+
+	this.selection.clear()
 }
 
 PhotoList.prototype.exists = function(path) {

--- a/photo.js
+++ b/photo.js
@@ -5,7 +5,7 @@
 function PhotoList() {
 	this.list = []; // new Set();
 
-	// this.selection
+	this.selection = new Set();
 }
 
 PhotoList.prototype.add = function(photo) {
@@ -15,7 +15,7 @@ PhotoList.prototype.add = function(photo) {
 
 PhotoList.prototype.remove = function(photo) {
 	var i = this.list.indexOf(photo);
-	this.list.slice(i, 1);
+	this.list.splice(i, 1);
 	this.save();
 }
 
@@ -31,8 +31,29 @@ PhotoList.prototype.items = function() {
 	return Array.from(this.list);
 }
 
+PhotoList.prototype.toJSON = function() {
+	this.list.map( p => { return {
+		filename: p.filename,
+		style: p.style
+	}} )
+}
+
 PhotoList.prototype.save = function() {
 	localStorage.lastLoad = JSON.stringify(this.filenames());
+	// localStorage.lastLoad = JSON.stringify(this.toJSON());
+}
+
+PhotoList.prototype.load = function() {
+	// TODO
+	var lastLoad = localStorage.lastLoad;
+	if (lastLoad) {
+		var list = JSON.parse(lastLoad);
+		list.forEach( json => {
+			this.list.push(
+				new Photo()
+			)
+		} );
+	}
 }
 
 PhotoList.prototype.empty = function() {
@@ -40,11 +61,19 @@ PhotoList.prototype.empty = function() {
 	this.save();
 }
 
+PhotoList.prototype.exists = function(path) {
+	return this.list.some( p => p.filename === path );
+}
+
+PhotoList.prototype.filter = function(path) {
+	return this.list.filter( p => p.filename === path );
+}
+
 function Photo(filename, img, orientation) {
 	this.filename = filename;
 	this.img = img;
 	this.orientation = orientation;
 
-	// styles
-	// adjustments
+	this.effect = null;
+	this.adjustment = '';
 }

--- a/photo.js
+++ b/photo.js
@@ -11,11 +11,14 @@ function PhotoList() {
 PhotoList.prototype.add = function(photo) {
 	this.list.push(photo);
 	this.save();
+	// this.selection.add(photo);
 }
 
 PhotoList.prototype.remove = function(photo) {
 	var i = this.list.indexOf(photo);
 	this.list.splice(i, 1);
+	
+	this.selection.delete(photo);
 	this.save();
 }
 

--- a/photo.js
+++ b/photo.js
@@ -35,6 +35,11 @@ PhotoList.prototype.save = function() {
 	localStorage.lastLoad = JSON.stringify(this.filenames());
 }
 
+PhotoList.prototype.empty = function() {
+	this.list = [];
+	this.save();
+}
+
 function Photo(filename, img, orientation) {
 	this.filename = filename;
 	this.img = img;


### PR DESCRIPTION
For current feature set (no adjustments, only filters + export), improve the following.

Checklist
- [x] Image border radius should be rounded
- [x] Image Saving options should go into a dialog (or hidden by default)
- [x] Clear / remove photos
- [x] Toggle Effects Tray
- [ ] ~~Effects photo selection~~
- [x] Dock / Toggle Loupe <-> Grid modes nicely

Other explorations TODO
- use grid squares
- use square borders
- use smart crop
- use masonry layout

Current state:
![lightbroom 0 2b](https://cloud.githubusercontent.com/assets/314997/12075413/138498bc-b1bb-11e5-8c37-181055b59331.gif)
